### PR TITLE
Auto-install coding standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ There are several reasons for that:
 1. The installer plugin [looks](https://github.com/PHPCSStandards/composer-installer/blob/290bcb677628f4d829f64a4337bf0b9237238f0b/src/Plugin.php#L47) for a different installed package, `squizlabs/php_codesniffer` to add more standards to
 2. The plugin creates a configuration file with a relative path to the standard being installed, so the code sniffer then expects the standard to be present inside the phar file, which is not the case
 
-However, there are multiple ways to install the standard manually. Let's say you want to add [`slevomat/coding-standard`](https://github.com/slevomat/coding-standard), you can:
+However, there are multiple different ways to install a standard. Let's say you want to add [`slevomat/coding-standard`](https://github.com/slevomat/coding-standard), you can:
+
+### Auto-install the available standards
+If the `CodeSniffer.conf` file doesn't exist, this package will find and auto-install all available coding standards on each execution.
+The altered configuration is not persisted, no config file will be created, because it would be removed on each package update anyway.
+This is the recommended option emulating the Standards Composer Installer Plugin to a certain point.
+
 ### Modify the config file
 1. In your project, run
    ```
    vendor/bin/phpcs --config-set installed_paths ../../slevomat/coding-standard
    ```
 3. Locate the `CodeSniffer.conf` file in your `vendor/spaze/phpcs-phar` directory
-4. Edit the path to the installed standard and make it an absolute path, for example change 
+4. Edit the path to the installed standard and make it an absolute path, for example change
    ```php
    'installed_paths' => '../../slevomat/coding-standard'
    ```
@@ -43,9 +49,13 @@ However, there are multiple ways to install the standard manually. Let's say you
    ```php
    'installed_paths' => __DIR__ . '/../../slevomat/coding-standard'
    ```
+Please be aware that the `CodeSniffer.conf` file will be removed on each package update.
+
 ### Install the standard using an absolute path
 In your project, run
 ```
 vendor/bin/phpcs --config-set installed_paths $(realpath vendor/slevomat/coding-standard)
 ```
 or use any absolute path for the `installed_paths` value.
+
+Please be aware that the `CodeSniffer.conf` file will be removed on each package update.

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,15 @@
 		"phpcsstandards/php_codesniffer": "3.10.1",
 		"squizlabs/php_codesniffer": "3.10.1"
 	},
+	"require": {
+		"composer-runtime-api": "^2.1"
+	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.4",
 		"php-parallel-lint/php-console-highlighter": "^1.0"
+	},
+	"autoload": {
+		"psr-4": {"Spaze\\PHPCSPhar\\": "src"}
 	},
 	"bin": [
 		"phpcbf",

--- a/phpcbf
+++ b/phpcbf
@@ -6,9 +6,9 @@ if (is_file(__DIR__ . '/../../autoload.php')) {
 	require_once __DIR__ . '/../../autoload.php';
 }
 
-// Need to skip the stub because phpcbf will be executed, not phpcs
 Phar::loadPhar(__DIR__ . '/phpcs.phar', 'phpcs.phar');
-require_once "phar://phpcs.phar/autoload.php";
+require_once 'phar://phpcs.phar/autoload.php';
 
+Spaze\PHPCSPhar\StandardsInstaller::install();
 $status = (new PHP_CodeSniffer\Runner())->runPHPCBF();
 exit($status);

--- a/phpcs
+++ b/phpcs
@@ -6,6 +6,9 @@ if (is_file(__DIR__ . '/../../autoload.php')) {
 	require_once __DIR__ . '/../../autoload.php';
 }
 
-// Require is enough to execute the phar stub that will run the tool,
-// see https://www.php.net/phar.createdefaultstub for more info
-require_once __DIR__ . '/phpcs.phar';
+Phar::loadPhar(__DIR__ . '/phpcs.phar', 'phpcs.phar');
+require_once 'phar://phpcs.phar/autoload.php';
+
+Spaze\PHPCSPhar\StandardsInstaller::install();
+$status = (new PHP_CodeSniffer\Runner())->runPHPCS();
+exit($status);

--- a/src/StandardsInstaller.php
+++ b/src/StandardsInstaller.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPCSPhar;
+
+use Composer\InstalledVersions;
+use PHP_CodeSniffer\Config;
+
+class StandardsInstaller
+{
+
+	public static function install(): void
+	{
+		if (!Config::getConfigData('installed_paths')) {
+			$packages = InstalledVersions::getInstalledPackagesByType('phpcodesniffer-standard');
+			$packages = array_unique($packages);
+			sort($packages);
+			$paths = [];
+			foreach ($packages as $package) {
+				$paths[] = InstalledVersions::getInstallPath($package);
+			}
+			Config::setConfigData('installed_paths', implode(',', $paths), true);
+		}
+	}
+
+}


### PR DESCRIPTION
If the `CodeSniffer.conf` file doesn't exist, this package will find and auto-install all available coding standards on each execution.
The altered configuration is not persisted, no config file will be created, because it would be removed on each package update anyway.