### PR TITLE
Different GPG server and key

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: "Verify GPG signature"
       run: |-
-        gpg --no-default-keyring --keyring trustedkeys.kbx --receive-keys 689DAD778FF08760E046228BA978220305CD5C32
+        gpg --no-default-keyring --keyring trustedkeys.kbx --keyserver hkps://keyserver.ubuntu.com --receive-keys 689DAD778FF08760E046228BA978220305CD5C32
         gpgv phpcs.phar.asc phpcs.phar
     - name: "Fetch phpcs.xsd"
       run: wget --timestamping https://github.com/PHPCSStandards/PHP_CodeSniffer/raw/${{ steps.fetch_phar.outputs.version }}/phpcs.xsd

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: "Verify GPG signature"
       run: |-
-        gpg --no-default-keyring --keyring trustedkeys.kbx --keyserver hkps://keyserver.ubuntu.com --receive-keys 689DAD778FF08760E046228BA978220305CD5C32
+        gpg --no-default-keyring --keyring trustedkeys.kbx --keyserver hkps://keyserver.ubuntu.com --receive-keys 689DAD778FF08760E046228BA978220305CD5C32 D91D86963AF3A29B6520462297B02DD8E5071466
         gpgv phpcs.phar.asc phpcs.phar
     - name: "Fetch phpcs.xsd"
       run: wget --timestamping https://github.com/PHPCSStandards/PHP_CodeSniffer/raw/${{ steps.fetch_phar.outputs.version }}/phpcs.xsd


### PR DESCRIPTION
Use a different keyserver, the default doesn't import user ids for expired keys
Import also the new 2025 key.

See #1
