### PR TITLE
❌ In PHPCS 4.0, `Config::setConfigData()` is not static anymore

### DIFF
--- a/src/StandardsInstaller.php
+++ b/src/StandardsInstaller.php
@@ -19,7 +19,8 @@ class StandardsInstaller
 			foreach ($packages as $package) {
 				$paths[] = InstalledVersions::getInstallPath($package);
 			}
-			Config::setConfigData('installed_paths', implode(',', $paths), true);
+			$config = new Config();
+			$config->setConfigData('installed_paths', implode(',', $paths), true);
 		}
 	}
 


### PR DESCRIPTION
_Note: The commit in this PR was removed from the main branch and the whole PR was replaced with #8._